### PR TITLE
django_admin_logs disabled

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_admin_logs',
     'import_export',
     'crispy_forms',
     'pleethai',
@@ -152,6 +153,7 @@ STATICFILES_DIRS = (
 )
 
 # Admin
+DJANGO_ADMIN_LOGS_ENABLED = False
 APPEND_TABLES_MAX_NUM = 300
 
 # Mail send

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ diff-match-patch==20181111
 dj-database-url==0.5.0
 dj-static==0.0.6
 Django==3.0.7
+django-admin-logs==1.0.1
 django-crispy-forms==1.9.0
 django-gmailapi-backend==0.1.0
 django-import-export==2.0.2


### PR DESCRIPTION
Not add records of "django_admin_log" table when admin-operations
(This is for Heroku environment)